### PR TITLE
Use beautifulsoup4 instead of the dummy module name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     version=__version__,
-    install_requires=["pygithub", "matplotlib", "requests", "bs4"],
+    install_requires=["pygithub", "matplotlib", "requests", "beautifulsoup4"],
     description="Command line tools for GitHub repo statistics",
     author="mrbean-bremen",
     author_email="hansemrbean@googlemail.com",


### PR DESCRIPTION
Distributions usually don't have `bs4` but `beautifulsoup4`. Avoid that they have to patch it.